### PR TITLE
Add zex instructions

### DIFF
--- a/src/moxie.cc
+++ b/src/moxie.cc
@@ -527,8 +527,24 @@ sim_resume (machine& mach, unsigned long long cpu_budget)
 		cpu.asregs.regs[a] = (int) bv;
 	      }
 	      break;
-	    case 0x12: /* bad */
-	    case 0x13: /* bad */
+	    case 0x12: /* zex.b */
+	      {
+		int a = (inst >> 4) & 0xf;
+		int b = inst & 0xf;
+		signed char bv = cpu.asregs.regs[b];
+		TRACE("zex.b");
+		cpu.asregs.regs[a] = (int) bv & 0xff;
+	      }
+	      break;
+	    case 0x13: /* zex.s */
+	      {
+		int a = (inst >> 4) & 0xf;
+		int b = inst & 0xf;
+		signed short bv = cpu.asregs.regs[b];
+		TRACE("zex.s");
+		cpu.asregs.regs[a] = (int) bv & 0xffff;
+	      }
+	      break;
 	    case 0x14: /* bad */
 	    case 0x15: /* bad */
 	    case 0x16: /* bad */


### PR DESCRIPTION
sha256 test was failing due to use of zex instruction w/ newest gcc git,
Patch from https://sourceware.org/ml/gdb-patches/2014-12/msg00279.html
