### PR TITLE
Update binutils-gdb source tree check

### DIFF
--- a/contrib/build-moxiebox-tools.sh
+++ b/contrib/build-moxiebox-tools.sh
@@ -28,7 +28,7 @@ if ! test -f src/src-release; then
   exit 1
 fi
 
-if ! test -f binutils-gdb/src-release; then
+if ! test -f binutils-gdb/src-release*; then
   echo "ERROR: missing binutils-gdb tree."
   exit 1
 fi


### PR DESCRIPTION
The toolchain build script checks for the existence of certain files before commencing the build.  The binutils-gdb file we were tracking actually changed names, causing the script to file.  This patch fixes the test.
