### PR TITLE
Fix mul.x invalid cast (64bits signed multiplication, result overflow)

### DIFF
--- a/src/moxie.cc
+++ b/src/moxie.cc
@@ -526,8 +526,7 @@ sim_resume (machine& mach, unsigned long long cpu_budget)
 		int b = inst & 0xf;
 		unsigned av = cpu.asregs.regs[a];
 		unsigned bv = cpu.asregs.regs[b];
-		signed long long r = 
-		  (signed long long) av * (signed long long) bv;
+		signed long long r = (signed) av * (signed) bv;
 
 		TRACE("mul.x");
 		cpu.asregs.regs[a] = r >> 32;


### PR DESCRIPTION
```
signed long long r = 
		  (signed long long) av * (signed long long) bv;
```
`av` and `bv` are 32bits signed integers, casting them to `signed long long` leads to a multiplication result which is too big for `r`.
As a consequence the multiplication behaves like and unsigned one, leading to 0 padded upper bits and an invalid `mul.x` result.

Casting `av` and `bv` to signed 32bits operands gives the expected result.